### PR TITLE
+ Aws specific changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Discovery strategy for AWS ECS.
 
 This discovery strategy uses the AWS ECS API to enumerate address of containers in tasks for a given service and cluster.
 
+Cluster and Services names can be filtered using `cluster-name-regexp` as well as `service-name-regexp` as you might 
+want to deploy to different environments (dev, stage, prod).
+
 Currently the task definition name cannot be filtered. You can however filter on the container name inside the task
 by setting a regexp in `container-name-regexp`.
 
@@ -31,7 +34,9 @@ $ aws iam get-policy-version --policy-arn arn:aws:iam::...:policy/EcsTaskRole-al
                 {
                     "Action": [
                         "ecs:ListTasks",
-                        "ecs:DescribeTasks"
+                        "ecs:DescribeTasks",
+                        "ecs:ListClusters",
+                        "ecs:ListServices"
                     ],
                     "Resource": "*",
                     "Effect": "Allow",
@@ -89,6 +94,8 @@ be overriden if required.
                         <property name="cluster">ikentoo-services-trial</property>
                         <property name="service">ik-waitlist-trial</property>
                         <!-- below are optional, prefer using a ecs task role with right policy/permission--> 
+                        <property name="cluster-name-regexp">.*ikentoo-dev-cluster.*</property>
+                        <property name="service-name-regexp">.*ikentoo-dev-service.*</property>
                         <property name="ports">5701-5702</property>
                         <property name="container-name-regexp">.*</property>
                         <property name="access-key">somekey</property>
@@ -104,3 +111,73 @@ be overriden if required.
 
 
 ```
+## Property configuration
+```java
+
+
+     
+    /**
+    * Setup Properties
+    */
+    Map<String, Comparable> properties = new HashMap<>();
+    properties.put("cluster", "ikentoo-services-trial");
+    properties.put("service", "ik-waitlist-trial");
+
+    /**
+    * Alternatively or in Combination with regexp for cluster / service name,
+    * cluster / service properties if available will overwrite the regexps
+    */
+    properties.put("cluster-name-regexp", ".*-dev-.*");
+    properties.put("service-name-regexp", ".*-backend-.*-dev$");
+    
+    properties.put("ports", "5701-5702");
+    properties.put("container-name-regexp", ".*");
+    properties.put("fail-fast", "true");
+    
+    properties.put("region", "us-east-1");
+    properties.put("access-key", "<somekey>");
+    properties.put("secret-key", "<somekey>");
+
+    /**
+    * Hazelcast Configuration
+    */ 
+    DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(awsEcsDiscoveryStrategyFactory, properties);
+    joinConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(discoveryStrategyConfig);
+
+``` 
+
+## Integration / Behavior Testing
+
+Please use provided integration test `AwsEcsDiscoveryStrategyIT` to test behavior of `discoveryNodes()` and resulting 
+clusters and services names based on set parameters. You need to provide valid `AWS_ACCESS_KEY`, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION`
+as environment variables as well as `CLUSTER_NAME`, `CLUSTER_NAME_REGEXP`, `SERVICE_NAME` and `SERVICE_NAME_REGEXP` for filtering.
+
+To execute the test simply use the following command line. 
+```bash 
+export AWS_SECRET_ACCESS_KEY=rmxxxxx
+export AWS_ACCESS_KEY=AKIxxxx
+export AWS_DEFAULT_REGION=us-east-1
+
+export CLUSTER_NAME=testing-xxxxx-cluster-ecs-stack-us-east-1-dev-EcsCluster-32XXXXXXXX
+export CLUSTER_NAME_REGEXP=.*-dev-.*
+export SERVICE_NAME=service/xxxxx-testing-backend-delivery-system-dev
+export SERVICE_NAME_REGEXP=.*-backend-.*-dev$
+
+mvn clean test -Dtest=AwsEcsDiscoveryStrategyIT
+
+
+[main] DEBUG simple - SYSTEM_ENV={PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Applications/Wireshark.app/Contents/MacOS, ... }
+[main] DEBUG simple - AWS_META={     "Cluster": "default",     "ContainerInstanceARN": ... }
+[main] DEBUG simple - TaskARN=arn:aws:ecs:us-west-2:012345678910:task/d90675f8-1a98-444b-805b-3d9cabb6fcd4
+[main] DEBUG simple - Discovering nodes in AWS ECS {cluster=testing-xxxx-cluster-ecs-stack-us-east-1-dev-EcsCluster-32XXXXXXXX, secret-key=rm..., service-name-regexp=.*-backend-.*-dev$, access-key=AK..., region=us-east-1}
+[main] DEBUG simple - Using Cluster Name Regexp 'testing-xxxxx-cluster-ecs-stack-us-east-1-dev-EcsCluster-32XXXXXXXX'
+[main] DEBUG simple - Using Service Name Regexp '.*-backend-.*-dev$'
+[main] DEBUG simple - Found Cluster 'arn:aws:ecs:us-east-1:686xxxxxxxxx:cluster/testing-xxxx-cluster-ecs-stack-us-east-1-dev-EcsCluster-32XXXXXXXX'
+[main] DEBUG simple - Found Service 'arn:aws:ecs:us-east-1:686xxxxxxxxx:service/xxxx-testing-backend-kv-dev'
+[main] DEBUG simple - Found Service 'arn:aws:ecs:us-east-1:686xxxxxxxxx:service/xxxx-testing-backend-api-settings-cache-dev'
+[main] DEBUG simple - Found Service 'arn:aws:ecs:us-east-1:686xxxxxxxxx:service/xxxx-testing-backend-delivery-system-dev'
+[main] DEBUG simple - 3 Tasks Found : [arn:aws:ecs:us-east-1:686xxxxxxxxx:task/0376050b-d3f6-4f5d-9cc5-c3d9e0c13ef9, arn:aws:ecs:us-east-1:686xxxxxxxxx:task/f7d7982e-4734-4929-bc54-e0dc6f3f4eb5, ...]
+[main] DEBUG simple - 2 Addresses Found : [[10.192.21.126]:5701, [10.192.20.28]:5701]
+[main] INFO simple - Private / Public Address Found : [10.192.20.28]:5701 / [10.192.20.28]:5701
+[main] INFO simple - Private / Public Address Found : [10.192.21.126]:5701 / [10.192.21.126]:5701
+``

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <hazelcast.version>3.11.2</hazelcast.version>
         <aws.sdk.version>1.11.527</aws.sdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
     </properties>
 
     <dependencies>
@@ -66,6 +68,16 @@
             <version>1.7.26</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.26</version>
+            <scope>test</scope>
+        </dependency>
+
+
+
     </dependencies>
 
 </project>

--- a/src/main/java/com/ikentoo/hazelcast/AwsEcsProperties.java
+++ b/src/main/java/com/ikentoo/hazelcast/AwsEcsProperties.java
@@ -33,8 +33,10 @@ import static java.lang.String.format;
 @SuppressWarnings("raw")
 public enum AwsEcsProperties {
 
-    cluster(false, STRING, null),
-    service(false, STRING, null),
+    cluster(true, STRING, null),
+    cluster_name_regexp( true, STRING, null),
+    service(true, STRING, null),
+    service_name_regexp( true, STRING, null),
     ports(true, STRING, value -> new PortRange((String) value)),
     container_name_regexp(true, STRING, null),
     access_key(true, STRING, null),
@@ -108,6 +110,37 @@ public enum AwsEcsProperties {
         String getServiceName() {
             return (String) properties.get(service.key());
         }
+
+        String getClusterNameRegexp() {
+
+            /**
+             * if cluster was passed set it as regexp for full match
+             */
+            if (properties.containsKey(cluster.key()) && getClusterName() != null && getClusterName().trim().length() > 0)
+                return getClusterName();
+
+            /**
+             * Otherwise return regexp if set, otherwise wildcard
+             */
+            return (String) properties.getOrDefault(cluster_name_regexp.key(), ".*");
+        }
+
+        String getServiceNameRegexp() {
+
+            /**
+             * if service was passed set it as regexp for full match
+             */
+            if (properties.containsKey(service.key()) && getServiceName() != null && getServiceName().trim().length() > 0)
+                return getServiceName();
+
+            /**
+             * Otherwise return regexp if set, otherwise wildcard
+             */
+            return (String) properties.getOrDefault(service_name_regexp.key(), ".*");
+
+        }
+
+
 
         IntStream getPorts() {
             String portSpec = (String) properties.get(ports.key());

--- a/src/test/java/com/ikentoo/hazelcast/AwsEcsDiscoveryStrategyIT.java
+++ b/src/test/java/com/ikentoo/hazelcast/AwsEcsDiscoveryStrategyIT.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2019, iKentoo SA. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.ikentoo.hazelcast;
+
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Slf4jFactory;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.junit.Assert.*;
+
+public class AwsEcsDiscoveryStrategyIT {
+    @Rule
+    public final EnvironmentVariables environmentVariables
+            = new EnvironmentVariables();
+
+
+    Map<String, Comparable> properties = new HashMap<>();
+
+    ILogger ilogger;
+
+
+    static { System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE"); }
+
+    /**
+     * Use statics to define your cluster / service name as well as the regexps for them to test against
+     */
+    String cluster_name;
+    String cluster_name_regexp;
+
+    String service_name;
+    String service_name_regexp;
+
+
+    @Before
+    public void setup() {
+
+        /**
+         * Configure logging
+         */
+        ilogger = new Slf4jFactory().getLogger("simple");
+
+        /**
+         * Check for existing aws access parameters
+         */
+        if (!System.getenv().containsKey("AWS_DEFAULT_REGION") ||
+                !System.getenv().containsKey("AWS_ACCESS_KEY") ||
+                !System.getenv().containsKey("AWS_SECRET_ACCESS_KEY")) {
+            fail("Please provide AWS_ACCESS_KEY, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION environment variables.");
+        }
+
+        /**
+         * extract cluster, service names as well as regexps
+         */
+        cluster_name = System.getenv("CLUSTER_NAME");
+        cluster_name_regexp = System.getenv("CLUSTER_NAME_REGEXP");
+
+        service_name = System.getenv("SERVICE_NAME");
+        service_name_regexp = System.getenv("SERVICE_NAME_REGEXP");
+
+        /**
+         * Show current name / regexp config
+         */
+        ilogger.info("CLUSTER_NAME = " + cluster_name );
+        ilogger.info("CLUSTER_NAME_REGEXP = " + cluster_name_regexp );
+        ilogger.info("SERVICE_NAME = " + service_name );
+        ilogger.info("SERVICE_NAME_REGEXP = " + service_name_regexp );
+
+        /**
+         * Setup Properties
+         */
+        properties.put("region", System.getenv("AWS_DEFAULT_REGION"));
+        properties.put("access-key", System.getenv("AWS_ACCESS_KEY"));
+        properties.put("secret-key", System.getenv("AWS_SECRET_ACCESS_KEY"));
+
+    }
+
+
+    @Test
+    public void testDiscoveryStrategyClusterRegExpServiceRegexp() throws IOException {
+
+        /**
+         * Set Task ARN through test file
+         */
+        Path tempFile = makeTaskFile();
+        environmentVariables.set("ECS_CONTAINER_METADATA_FILE", tempFile.toAbsolutePath().toString());
+
+
+        /**
+         * Configure logging
+         */
+        System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE");
+        ILogger ilogger = new Slf4jFactory().getLogger("simple");
+
+        /**
+         * Configure AwsEcsDiscoveryStrategy
+         */
+        AwsEcsDiscoveryStrategyFactory awsEcsDiscoveryStrategyFactory = new AwsEcsDiscoveryStrategyFactory();
+        properties.put("cluster-name-regexp", cluster_name_regexp);
+        properties.put("service-name-regexp", service_name_regexp);
+
+
+        /**
+         * Try to run discoversNodes() method
+         */
+        try {
+            AwsEcsDiscoveryStrategy strategy = new AwsEcsDiscoveryStrategy(ilogger, properties);
+            Iterator<DiscoveryNode> iterator =  strategy.discoverNodes().iterator();
+
+            assertTrue(iterator.hasNext());
+
+            while(iterator.hasNext()) {
+                DiscoveryNode discoveryNode =  iterator.next();
+                ilogger.info( "Private / Public Address Found : " + discoveryNode.getPrivateAddress() + " / " + discoveryNode.getPublicAddress());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void testDiscoveryStrategyClusterNameServiceRegExp() throws IOException{
+
+        /**
+         * Set Task ARN through test file
+         */
+        Path tempFile = makeTaskFile();
+        environmentVariables.set("ECS_CONTAINER_METADATA_FILE", tempFile.toAbsolutePath().toString());
+
+
+        /**
+         * Configure logging
+         */
+        System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE");
+        ILogger ilogger = new Slf4jFactory().getLogger("simple");
+
+        /**
+         * Configure AwsEcsDiscoveryStrategy
+         */
+        AwsEcsDiscoveryStrategyFactory awsEcsDiscoveryStrategyFactory = new AwsEcsDiscoveryStrategyFactory();
+        properties.put("cluster", cluster_name);
+        properties.put("service-name-regexp", service_name_regexp);
+
+        /**
+         * Try to run discoversNodes() method
+         */
+        try {
+            AwsEcsDiscoveryStrategy strategy = new AwsEcsDiscoveryStrategy(ilogger, properties);
+            Iterator<DiscoveryNode> iterator =  strategy.discoverNodes().iterator();
+
+            assertTrue(iterator.hasNext());
+
+            while(iterator.hasNext()) {
+                DiscoveryNode discoveryNode =  iterator.next();
+                ilogger.info( "Private / Public Address Found : " + discoveryNode.getPrivateAddress() + " / " + discoveryNode.getPublicAddress());
+            }
+
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void testDiscoveryStrategyClusterNameServiceName() throws IOException{
+
+        /**
+         * Set Task ARN through test file
+         */
+        Path tempFile = makeTaskFile();
+        environmentVariables.set("ECS_CONTAINER_METADATA_FILE", tempFile.toAbsolutePath().toString());
+
+        /**
+         * Configure AwsEcsDiscoveryStrategy
+         */
+        AwsEcsDiscoveryStrategyFactory awsEcsDiscoveryStrategyFactory = new AwsEcsDiscoveryStrategyFactory();
+        properties.put("cluster", cluster_name);
+        properties.put("service", service_name);
+
+
+        /**
+         * Try to run discoversNodes() method
+         */
+        try {
+            AwsEcsDiscoveryStrategy strategy = new AwsEcsDiscoveryStrategy(ilogger, properties);
+            Iterator<DiscoveryNode> iterator =  strategy.discoverNodes().iterator();
+
+            assertTrue(iterator.hasNext());
+
+            while(iterator.hasNext()) {
+                DiscoveryNode discoveryNode =  iterator.next();
+                ilogger.info( "Private / Public Address Found : " + discoveryNode.getPrivateAddress() + " / " + discoveryNode.getPublicAddress());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+
+    }
+
+    private Path makeTaskFile() throws IOException {
+
+        String example = "{\n" +
+                "    \"Cluster\": \"default\",\n" +
+                "    \"ContainerInstanceARN\": \"arn:aws:ecs:us-west-2:012345678910:container-instance/1f73d099-b914-411c-a9ff-81633b7741dd\",\n" +
+                "    \"TaskARN\": \"arn:aws:ecs:us-west-2:012345678910:task/d90675f8-1a98-444b-805b-3d9cabb6fcd4\",\n" +
+                "    \"ContainerName\": \"metadata\"\n" +
+                "}";
+
+        Path tempFile = Files.createTempFile("meta", "json");
+        Files.write(tempFile, example.getBytes(StandardCharsets.UTF_8));
+        return tempFile;
+    }
+}


### PR DESCRIPTION
++ Role / User has to have ecs:ListClusters and ecs:ListServices permissions

+ README.md
++ added some comments around new configuration options
++ added Property based Java configuration code example
++ added usage of AwsEcsDiscoveryStrategyIT integration test as well as result example.

+ AwsEcsProperties
++ added cluster_name_regexp and service_name_regexp configuration properties
++ added get methods for cluster/services_name_regexp
+++ Behavior : If cluster or service name is available it will be used as full match,
+++            otherwise if null / empty-post-trim the set regexp is used. Defaults to ".*" if not available.

+ AwsEcsDiscoveryStrategy
++ Changed Processing :
++ 1) get a list of clusters matching the passed cluster name if available
++    defaulting to passed cluster_name_regexp pattern if available, otherwise all clusters aws profile has access to
++ 2) For every cluster get a list of services matching the passed service name if available
++    defaulting to passed service_name_regexp if available, otherwise all services aws profile has access to
++ 2.1) Remove/filter out ownTask
++ 2.2) collect all tasks found, determine addresses of tasks (no change of implementation here)
++ 2.3) add addresses to list of addresses.(Downstream Code not changed)

+ AwsEcsDiscoveryStrategyIT
++ Some sort of  Integration Testing using available AWS parameters
++ (access key, secret key, region, cluster , cluster regexp, service, service regexp)

+ pom.xml
++ added UTF-8 source encoding property
++ added slf4j-simple depedency for testing purposes